### PR TITLE
Use Rust traits

### DIFF
--- a/src/cyclotomic.rs
+++ b/src/cyclotomic.rs
@@ -30,7 +30,7 @@
 // \section{Introduction}
 //
 // TODO: write something about GAP, Magma, cite some of those papers
-// about sparse and dense representations.
+//       about sparse and dense representations.
 //
 // \section{Implementation of GAP's algorithms}
 //
@@ -53,17 +53,19 @@
 extern crate num;
 
 use std::cmp::Eq;
-use std::ops::Add;
+use std::ops::{Add, Mul};
 use std::vec::Vec;
+use self::num::{One, Zero};
+use std::ptr::eq;
 
 type Z = num::bigint::BigInt;
 type Q = num::rational::BigRational;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Cyclotomic {
-    order: u64,     // n
-    coeffs: Vec<Q>, // c
-    exps: Vec<u64>, // e
+    order: u64     /*   n   */,
+    coeffs: Vec<Q> /*   c   */,
+    exps: Vec<u64> /*   e   */,
 }
 
 impl Cyclotomic {
@@ -97,80 +99,121 @@ impl Cyclotomic {
 
 // TODO: implement reduction so the order doesn't blow up
 
-pub fn zero() -> Cyclotomic {
-    Cyclotomic::new(1, vec![Q::new(Z::from(0), Z::from(1))], vec![0])
-}
-
-pub fn one() -> Cyclotomic {
-    Cyclotomic::new(1, vec![Q::new(Z::from(1), Z::from(1))], vec![0])
-}
-
-// TODO: right now we INCREASE the orders to get compatibility... we should try to
-// DECREASE order first!
-pub fn increase_order_to(z: &mut Cyclotomic, new_order: u64) -> () {
-    z.exps = z
-        .exps
-        .clone()
-        .into_iter()
-        .map(|k| new_order * k / z.order)
-        .collect();
-
-    z.order = new_order
-}
-
-// TODO: Use Rob's code to actually do some reductions here?
-pub fn match_orders(z1: &mut Cyclotomic, z2: &mut Cyclotomic) -> () {
-    let new_order = num::integer::lcm(z1.order, z2.order);
-    increase_order_to(z1, new_order);
-    increase_order_to(z2, new_order);
-}
-
-// Note: checking equality mutates the encoding of $z_1$ and $z_2$, but does not
-// change the values represented. Since we mutate, we cannot use the Rust traits
-// \tt{Eq} and \tt{PartialEq}. The same is true for all arithmetic operations.
-pub fn eq(z1: &mut Cyclotomic, z2: &mut Cyclotomic) -> bool {
-    match_orders(z1, z2);
-    // Since we assume the exponent list is sorted, we can just do a
-    // comparison of the coeff and exp vectors, the number is in
-    // canonical form.
-    z1.coeffs == z2.coeffs && z1.exps == z2.exps
-}
-
-pub fn add(z1: &mut Cyclotomic, z2: &mut Cyclotomic) -> Cyclotomic {
-    match_orders(z1, z2);
-
-    let mut z1_i = 0;
-    let mut z2_i = 0;
-    let mut result = zero();
-
-    // We are producing a result cyclotomic in canonical form assuming the
-    // inputs are in canonical form. That is, we build the result term by
-    // term, assuming that the exponent lists are sorted.
-    while z1_i < z1.exps.len() || z2_i < z2.exps.len() {
-        while z1_i < z1.exps.len() && z1.exps[z1_i] < z2.exps[z2_i] {
-            result.coeffs.push(z1.coeffs[z1_i].clone());
-            result.exps.push(z1.exps[z1_i].clone());
-            z1_i += 1;
-        }
-
-        while z2_i < z2.exps.len() && z2.exps[z2_i] < z1.exps[z1_i] {
-            result.coeffs.push(z2.coeffs[z2_i].clone());
-            result.exps.push(z2.exps[z2_i].clone());
-            z2_i += 1;
-        }
-
-        // If the exponents match up, we just add the coefficients - they are for the same term
-        if z1.exps[z1_i] == z2.exps[z2_i] {
-            result
-                .coeffs
-                .push(z1.coeffs[z1_i].clone() + z2.coeffs[z2_i].clone());
-            result.exps.push(z1.exps[z1_i]);
-            z1_i += 1;
-            z2_i += 1
-        }
+impl Zero for Cyclotomic {
+    fn zero() -> Self {
+        Cyclotomic::new(1, vec![Q::new(Z::from(0), Z::from(1))], vec![0])
     }
 
-    result
+    fn set_zero(&mut self) {
+        self.order = 1;
+        self.coeffs = vec![Q::new(Z::from(0), Z::from(1))];
+        self.exps = vec![]
+    }
+
+    fn is_zero(&self) -> bool {
+        return self.order == 1
+            && self.coeffs == vec![Q::new(Z::from(0), Z::from(1))]
+            && self.exps == vec![];
+    }
+}
+
+impl One for Cyclotomic {
+    fn one() -> Self {
+        Cyclotomic::new(1, vec![Q::new(Z::from(1), Z::from(1))], vec![0])
+    }
+}
+
+impl Cyclotomic {
+    // TODO: right now we INCREASE the orders to get compatibility... we should try to
+    // DECREASE order first!
+    pub fn increase_order_to(z: &mut Cyclotomic, new_order: u64) -> () {
+        z.exps = z
+            .exps
+            .clone()
+            .into_iter()
+            .map(|k| new_order * k / z.order)
+            .collect();
+
+        z.order = new_order
+    }
+
+    // TODO: Use Rob's code to actually do some reductions here?
+    pub fn match_orders(z1: &mut Cyclotomic, z2: &mut Cyclotomic) -> () {
+        let new_order = num::integer::lcm(z1.order, z2.order);
+        Cyclotomic::increase_order_to(z1, new_order);
+        Cyclotomic::increase_order_to(z2, new_order);
+    }
+}
+
+impl PartialEq for Cyclotomic {
+    // Note: checking equality mutates the encoding of $z_1$ and $z_2$, but does not
+    // change the values represented. Since we mutate, we cannot use the Rust traits
+    // \tt{Eq} and \tt{PartialEq}. The same is true for all arithmetic operations.
+    fn eq(&self, other: &Self) -> bool {
+        let mut z1 = self.clone();
+        let mut z2 = other.clone();
+        Cyclotomic::match_orders(&mut z1, &mut z2);
+        // Since we assume the exponent list is sorted, we can just do a
+        // comparison of the coeff and exp vectors, the number is in
+        // canonical form.
+        z1.coeffs == z2.coeffs && z1.exps == z2.exps
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        return !eq(self, other);
+    }
+}
+
+impl Add for Cyclotomic {
+    type Output = Cyclotomic;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut z1 = self.clone();
+        let mut z2 = rhs.clone();
+        Cyclotomic::match_orders(&mut z1, &mut z2);
+
+        let mut z1_i = 0;
+        let mut z2_i = 0;
+        let mut result = Cyclotomic::zero();
+
+        // We are producing a result cyclotomic in canonical form assuming the
+        // inputs are in canonical form. That is, we build the result term by
+        // term, assuming that the exponent lists are sorted.
+        while z1_i < z1.exps.len() || z2_i < z2.exps.len() {
+            while z1_i < z1.exps.len() && z1.exps[z1_i] < z2.exps[z2_i] {
+                result.coeffs.push(z1.coeffs[z1_i].clone());
+                result.exps.push(z1.exps[z1_i].clone());
+                z1_i += 1;
+            }
+
+            while z2_i < z2.exps.len() && z2.exps[z2_i] < z1.exps[z1_i] {
+                result.coeffs.push(z2.coeffs[z2_i].clone());
+                result.exps.push(z2.exps[z2_i].clone());
+                z2_i += 1;
+            }
+
+            // If the exponents match up, we just add the coefficients - they are for the same term
+            if z1.exps[z1_i] == z2.exps[z2_i] {
+                result
+                    .coeffs
+                    .push(z1.coeffs[z1_i].clone() + z2.coeffs[z2_i].clone());
+                result.exps.push(z1.exps[z1_i]);
+                z1_i += 1;
+                z2_i += 1
+            }
+        }
+
+        result
+    }
+}
+
+impl Mul for Cyclotomic {
+    type Output = Cyclotomic;
+
+    // I could have a guess at how to implement this, but I would inevitably embarrass myself.
+    fn mul(self, rhs: Self) -> Self::Output {
+        unimplemented!()
+    }
 }
 
 // \section{Improving performance}


### PR DESCRIPTION
Discovered that rust provides some sensible-looking traits (corresponds to C++ abstract classes which specify only purely virtual methods) for number types, so I wrapped the existing implementations in there without changing any of the implementation. To address any differences is method-signature, for now I just went trigger-happy with clone.

Edit 1: I don't actually know if I would describe this change as _good_. I'm not even sure what use it is to us, to implement these traits. The only side-effect that I do like with this change, is that in some sense, adopting the ecosystem's provided interfaces makes the implementations coherent within the context of the language.

What do you think of this change?