### PR TITLE
Non mutating match orders

### DIFF
--- a/src/cyclotomic.rs
+++ b/src/cyclotomic.rs
@@ -128,7 +128,7 @@ impl One for Cyclotomic {
 impl Cyclotomic {
     // TODO: right now we INCREASE the orders to get compatibility... we should
     //       try to DECREASE order first!
-    fn increase_order(&self, new_order: u64) -> Cyclotomic {
+    fn increase_order_to(&self, new_order: u64) -> Cyclotomic {
         Cyclotomic {
             order: new_order,
             coeffs: self.coeffs.clone(),
@@ -142,7 +142,7 @@ impl Cyclotomic {
     // TODO: Use Rob's code to actually do some reductions here?
     pub fn match_orders(z1: &Cyclotomic, z2: &Cyclotomic) -> (Cyclotomic, Cyclotomic) {
         let new_order = num::integer::lcm(z1.order, z2.order);
-        return (z1.increase_order(new_order), z2.increase_order(new_order));
+        return (z1.increase_order_to(new_order), z2.increase_order_to(new_order));
     }
 }
 

--- a/src/cyclotomic.rs
+++ b/src/cyclotomic.rs
@@ -70,11 +70,7 @@ pub struct Cyclotomic {
 
 impl Cyclotomic {
     pub fn new(order: u64, coeffs: Box<Vec<Q>>, exps: Box<Vec<u64>>) -> Cyclotomic {
-        Cyclotomic {
-            order,
-            coeffs: coeffs,
-            exps: exps,
-        }
+        Cyclotomic { order, coeffs, exps }
     }
 }
 
@@ -224,7 +220,39 @@ impl Mul for Cyclotomic {
 #[cfg(test)]
 mod cyclotomic_tests {
     use super::*;
+    use super::num::BigRational;
 
     #[test]
-    fn test_compilation() {}
+    #[ignore]
+    fn test_addition() {
+        let a = Cyclotomic::new(
+            5,
+            Box::new(vec![Q::new(Z::from(15), Z::from(4))]),
+            Box::new(vec![3]));
+
+        let b = Cyclotomic::new(
+            3,
+            Box::new(vec![Q::new(Z::from(3), Z::from(2))]),
+            Box::new(vec![2]));
+
+        let c = a + b;
+        println!("Result is {:?}", c)
+    }
+
+    #[test]
+    #[ignore]
+    fn test_multiplication() {
+        let a = Cyclotomic::new(
+            5,
+            Box::new(vec![Q::new(Z::from(15), Z::from(4))]),
+            Box::new(vec![3]));
+
+        let b = Cyclotomic::new(
+            3,
+            Box::new(vec![Q::new(Z::from(3), Z::from(2))]),
+            Box::new(vec![2]));
+
+        let c = a * b;
+        println!("Result is {:?}", c)
+    }
 }

--- a/src/cyclotomic.rs
+++ b/src/cyclotomic.rs
@@ -140,7 +140,7 @@ impl Cyclotomic {
     }
 
     // TODO: Use Rob's code to actually do some reductions here?
-    pub fn match_orders(z1: &Cyclotomic, z2: &Cyclotomic) -> (Cyclotomic, Cyclotomic) {
+    fn match_orders(z1: &Cyclotomic, z2: &Cyclotomic) -> (Cyclotomic, Cyclotomic) {
         let new_order = num::integer::lcm(z1.order, z2.order);
         return (z1.increase_order_to(new_order), z2.increase_order_to(new_order));
     }


### PR DESCRIPTION
I'm pretty sure this change sucks, which is why it's a draft PR and I don't really think it should be merged, but it's learning at least...

I changed the mutating `increase_order_to` function so that it was stateless and returned a new instance of Cyclotomic by reusing the data from the existing instance (rather than mutating the existing instance). I think this signature change is appropriate and would solve our issue in an idiomatic way (i.e. without lying about changes to data, while still changing it in-place).

The implementation however isn't very good I don't think, because it is still performing the mutation out-of-place (a couple of searches indicate that `Box::clone` clones the underlying data as well as the pointer). And so really this code is doing the same thing but with more code and more jargon.

A few searches indicate that an alternative to `Box` which allows for internal mutability is another smart pointer type, `Rc` and it's multithreaded counterpart, `Arc`.

The assertion-less tests I added don't run to completion, but they didn't before. Maybe we can look into that today 😁 

(Delete this PR and the branch once you've seen enough.)